### PR TITLE
✨ Add SocketContext

### DIFF
--- a/components/pages/Pages.stories.tsx
+++ b/components/pages/Pages.stories.tsx
@@ -12,4 +12,4 @@ export default {
 export const index = () => <Home />;
 export const rules = () => <Rules />;
 export const user = () => <User />;
-export const lobbies = () => <Lobbies socket={null} />;
+export const lobbies = () => <Lobbies />;

--- a/components/pages/Pages.stories.tsx
+++ b/components/pages/Pages.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/react/types-6-0";
+import { SocketContextProvider } from "../../contexts/SocketContext";
 import Home from "../../pages/index";
 import Lobbies from "../../pages/lobbies";
 import Rules from "../../pages/rules";
@@ -12,4 +13,8 @@ export default {
 export const index = () => <Home />;
 export const rules = () => <Rules />;
 export const user = () => <User />;
-export const lobbies = () => <Lobbies />;
+export const lobbies = () => (
+  <SocketContextProvider>
+    <Lobbies />
+  </SocketContextProvider>
+);

--- a/contexts/SocketContext.tsx
+++ b/contexts/SocketContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, ReactNode, useEffect, useState } from "react";
+import { io, Socket } from "socket.io-client";
+
+type SocketContextType = {
+  socket: Socket;
+};
+
+export const SocketContext = createContext<SocketContextType>(null);
+
+type SocketContextProviderProps = {
+  children: ReactNode;
+};
+
+export function SocketContextProvider({
+  children,
+}: SocketContextProviderProps) {
+  const [socket, setSocket] = useState<Socket>(null);
+
+  useEffect(() => {
+    const newSocket = io();
+
+    newSocket.on("connect", () => {
+      setSocket(newSocket);
+      console.log(newSocket.id + " connected");
+      localStorage.setItem("socketID", newSocket.id);
+    });
+  }, []);
+
+  return (
+    <SocketContext.Provider value={{ socket }}>
+      {children}
+    </SocketContext.Provider>
+  );
+}

--- a/lib/functions.ts
+++ b/lib/functions.ts
@@ -1,0 +1,7 @@
+export function getPlayerName() {
+  return localStorage.getItem("playerName");
+}
+
+export function getSocketID() {
+  return localStorage.getItem("socketID");
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,21 +1,13 @@
 import type { AppProps } from "next/app";
 import "../styles/globals.css";
-import { io, Socket } from "socket.io-client";
-import { useEffect, useState } from "react";
+import { SocketContextProvider } from "../contexts/SocketContext";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const [socket, setSocket] = useState<Socket>(null);
-
-  useEffect(() => {
-    const newSocket = io();
-
-    newSocket.on("connect", () => {
-      setSocket(newSocket);
-      console.log(newSocket.id + " connected");
-      localStorage.setItem("socketID", newSocket.id);
-    });
-  }, []);
-  return <Component socket={socket} {...pageProps} />;
+  return (
+    <SocketContextProvider>
+      <Component {...pageProps} />
+    </SocketContextProvider>
+  );
 }
 
 export default MyApp;

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -10,8 +10,26 @@ import DrawPile from "../components/gameboard/DrawPile";
 import DiscardPile from "../components/gameboard/DiscardPile";
 import CardGrid from "../components/gameboard/CardGrid";
 import OpponentCardGrid from "../components/gameboard/OpponentCardGrid";
+import { SocketContext } from "../contexts/SocketContext";
+import { useContext, useEffect } from "react";
+import { getPlayerName, getSocketID } from "../lib/functions";
 
 export default function Game() {
+  const { socket } = useContext(SocketContext);
+
+  useEffect(() => {
+    if (!socket) {
+      return;
+    }
+    const playerName = getPlayerName();
+    const socketID = getSocketID();
+
+    socket.emit("player joined", playerName, socketID);
+    socket.on("broadcast join", (player) => {
+      console.log(player + " joined ");
+    });
+  }, []);
+
   return (
     <>
       <Head>

--- a/pages/lobbies.tsx
+++ b/pages/lobbies.tsx
@@ -8,16 +8,13 @@ import LobbyListItem, {
   LobbyListItemProps,
 } from "../components/misc/LobbyListItem";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import { Socket } from "socket.io-client";
+import { useContext, useEffect, useState } from "react";
+import { SocketContext } from "../contexts/SocketContext";
 
-type LobbiesProps = {
-  socket: Socket;
-};
-
-export default function Lobbies({ socket }: LobbiesProps) {
+export default function Lobbies() {
   const router = useRouter();
   const [lobbyItems, setLobbyItems] = useState<LobbyListItemProps[]>([]);
+  const { socket } = useContext(SocketContext);
 
   useEffect(() => {
     if (!socket) {

--- a/pages/lobbies.tsx
+++ b/pages/lobbies.tsx
@@ -10,6 +10,7 @@ import LobbyListItem, {
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 import { SocketContext } from "../contexts/SocketContext";
+import { getPlayerName, getSocketID } from "../lib/functions";
 
 export default function Lobbies() {
   const router = useRouter();
@@ -36,16 +37,8 @@ export default function Lobbies() {
     const playerName = getPlayerName();
     const socketID = getSocketID();
     socket.emit("join game", lobbyNr, playerName, socketID);
-    // goToLobby(lobbyNr);
+    goToLobby(lobbyNr);
   };
-
-  function getPlayerName() {
-    return localStorage.getItem("playerName");
-  }
-
-  function getSocketID() {
-    return localStorage.getItem("socketID");
-  }
 
   const handleCreateBtnClick = () => {
     const playerName = getPlayerName();

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -33,7 +33,8 @@ export function createGame(
     drawPileCards: [],
     discardPileCards: [],
   };
-  console.log(JSON.stringify(games, null, 4));
+  //commented out for now
+  // console.log(JSON.stringify(games, null, 4));
 }
 
 function checkIsLobbyFull(lobbyNr) {
@@ -70,4 +71,10 @@ export function getGames() {
       lobbyIsFull: game.lobbyIsFull,
     };
   });
+}
+
+export function getGameBySocketID(socketID) {
+  return Object.values(games).find((game) =>
+    game.players.find((id) => id.socketID === socketID)
+  ).lobbyNr;
 }

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -1,5 +1,5 @@
 import { Server, Socket } from "socket.io";
-import { createGame, getGames, joinGame } from "./lib/games";
+import { createGame, getGameBySocketID, getGames, joinGame } from "./lib/games";
 
 let io;
 
@@ -35,6 +35,11 @@ export function listenSocket(server) {
       socket.join(`lobby${lobbyNr}`);
       joinGame(lobbyNr, playerName, socketID);
       broadcastListGamesUpdate();
+    });
+
+    socket.on("player joined", (playerName, socketID) => {
+      const currentGame = getGameBySocketID(socketID);
+      io.to(`lobby${currentGame}`).emit("broadcast join", playerName);
     });
   });
 }


### PR DESCRIPTION
- Add SocketContextProvider in app.tsx
- `socket` is no longer being passed down as props
- `socket` is now accessible in every Page by using `useContext()`

I decided to use Context, making it easier to access `socket`.
This will help in my next steps, because I am going to need `socket` in my game page aswell.

Deployment: https://sisu-pipelin-socketcont-6r2wwr.herokuapp.com/
Fixes #42