### PR TITLE
✨ Add functions to render opponent cardGrids

### DIFF
--- a/components/gameboard/GameBoard.stories.tsx
+++ b/components/gameboard/GameBoard.stories.tsx
@@ -28,7 +28,7 @@ export const drawpile = () => <DrawPile onClick={() => alert("test")} />;
 export const discardpile = () => <DiscardPile onClick={() => alert("test")} />;
 export const totalscore = () => <TotalScore />;
 export const cardgrid = () => <CardGrid />;
-export const opponentcardgrid = () => <OpponentCardGrid />;
+// export const opponentcardgrid = () => <OpponentCardGrid />;
 export const roundscoremodal = () => <RoundScoreModal />;
 export const roundcounter = () => (
   <SocketContextProvider>

--- a/components/gameboard/OpponentCardGrid.tsx
+++ b/components/gameboard/OpponentCardGrid.tsx
@@ -1,47 +1,34 @@
+import { MouseEventHandler } from "react";
+import { Card } from "../../server/lib/gameTypes";
 import styles from "./CardGrid.module.css";
 
-function OpponentCardGrid(onClick) {
-  // Example data, will be removed later by Props handed down to CardGrid
-  const players = [
-    { name: "Frederik", score: 20 },
-    { name: "Kalle", score: 10 },
-    { name: "Eva", score: 30 },
-    { name: "Louis", score: 60 },
-    { name: "Frederik", score: 20 },
-    { name: "Kalle", score: 10 },
-    { name: "Eva", score: 30 },
-    { name: "Peter", score: 30 },
-  ];
-  // Example data, will be removed later by Props handed down to CardGrid
-  const cards = [
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 8, hidden: true, src: "/cards/08.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 6, hidden: false, src: "/cards/06.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 7, hidden: true, src: "/cards/07.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-    { value: 12, hidden: false, src: "/cards/12.png" },
-    { value: 1, hidden: true, src: "/cards/01.png" },
-  ];
+export type OpponentCardGridProps = {
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  cards: Card[];
+  name: string;
+  roundScore: number[];
+};
 
+function OpponentCardGrid({
+  // onClick,
+  cards,
+  name,
+  roundScore,
+}: OpponentCardGridProps) {
   const createPlayerCardGrid = cards.map((card) => (
     <img
       key={card.value}
-      src={card.hidden ? "/cards/back.png" : card.src}
-      onClick={onClick}
+      src={card.hidden ? "/cards/back.png" : card.imgSrc}
+      // onClick={onClick}
     />
   ));
 
   return (
     <section className={styles.opponentContainer}>
       <p>
-        Score: <span>{players[0].score}</span>
+        Score: <span>{roundScore}</span>
       </p>
-      <p>{players[0].name}</p>
+      <p>{name}</p>
       <div className={styles.oppCardGrid}>{createPlayerCardGrid}</div>
     </section>
   );

--- a/components/gameboard/TotalScore.tsx
+++ b/components/gameboard/TotalScore.tsx
@@ -13,11 +13,11 @@ function TotalScore() {
   const [scoreList, setScoreList] = useState<ScoreListProps[]>([]);
   const lobbyNr = getLobbyNr();
 
-  const renderScoreList = scoreList.map((player) => {
+  const renderScoreList = scoreList.map(({ name, totalScore }) => {
     return (
-      <li key={player.name} className={styles.playerListItem}>
-        <span className={styles.playerName}>{player.name}</span>
-        <span className={styles.playerScore}>{player.totalScore}</span>
+      <li key={name} className={styles.playerListItem}>
+        <span className={styles.playerName}>{name}</span>
+        <span className={styles.playerScore}>{totalScore}</span>
       </li>
     );
   });

--- a/components/gameboard/TotalScore.tsx
+++ b/components/gameboard/TotalScore.tsx
@@ -16,7 +16,7 @@ function TotalScore() {
   const renderScoreList = scoreList.map((player) => {
     return (
       <li key={player.name} className={styles.playerListItem}>
-        <span className={styles.playerName}>{player.name}</span>{" "}
+        <span className={styles.playerName}>{player.name}</span>
         <span className={styles.playerScore}>{player.totalScore}</span>
       </li>
     );

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -21,7 +21,7 @@ export default function Game() {
   const router = useRouter();
   const lobbyNr = getLobbyNr();
   const [playerCount, setPlayerCount] = useState<number>(null);
-  const [players, setPlayers] = useState<PlayerForCardGrid[]>(null);
+  const [players, setPlayers] = useState<PlayerForCardGrid[]>([]);
 
   useEffect(() => {
     if (!socket || !lobbyNr) {
@@ -63,35 +63,41 @@ export default function Game() {
     }
   };
 
-  const renderOpponentCardGrids = () => {
-    // if (playerCount === 8) {
-    //   return (
-    //     <div className={styles.opponents}>
-    //       <div className={styles.op8row}>
-    //         <OpponentCardGrid />
-    //         <OpponentCardGrid />
-    //       </div>
-    //       <OpponentCardGrid />
-    //       <OpponentCardGrid />
-    //       <OpponentCardGrid />
-    //       <OpponentCardGrid />
-    //       <div className={styles.op8row}>
-    //         <OpponentCardGrid />
-    //         <OpponentCardGrid />
-    //       </div>
-    //     </div>
-    //   );
-    // }
+  const opponentCardGrids = players.map(
+    ({ name, cards, roundScore, socketID }) => {
+      return (
+        <OpponentCardGrid
+          key={socketID}
+          cards={cards}
+          name={name}
+          roundScore={roundScore}
+        />
+      );
+    }
+  );
 
-    return players.map(({ name, cards, roundScore, socketID }) => (
-      <OpponentCardGrid
-        key={socketID}
-        cards={cards}
-        name={name}
-        roundScore={roundScore}
-      />
-    ));
-  };
+  // const renderOpponentCardGrids = () => {
+  //   // if (playerCount === 8) {
+  //   //   return (
+  //   //     <div className={styles.opponents}>
+  //   //       <div className={styles.op8row}>
+  //   //         <OpponentCardGrid />
+  //   //         <OpponentCardGrid />
+  //   //       </div>
+  //   //       <OpponentCardGrid />
+  //   //       <OpponentCardGrid />
+  //   //       <OpponentCardGrid />
+  //   //       <OpponentCardGrid />
+  //   //       <div className={styles.op8row}>
+  //   //         <OpponentCardGrid />
+  //   //         <OpponentCardGrid />
+  //   //       </div>
+  //   //     </div>
+  //   //   );
+  //   // }
+
+  //   return opponentCardGrids;
+  // };
 
   return (
     <>
@@ -119,12 +125,8 @@ export default function Game() {
             <DiscardPile onClick={() => alert("click")} />
           </aside>
           <div className={styles.gameElements8Player}>
-            <div className={styles.opponents}>
-              {() => renderOpponentCardGrids}
-            </div>
-            <div className={styles.playerCardGrid}>
-              <CardGrid />
-            </div>
+            <div className={styles.opponents}>{opponentCardGrids}</div>
+            <div className={styles.playerCardGrid}>{/* <CardGrid /> */}</div>
           </div>
         </div>
       </main>

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -35,15 +35,17 @@ export default function Game() {
     }
 
     function handleDisplayPlayers(players: PlayerForCardGrid[]) {
-      console.log("players", players);
-      setPlayers(players);
+      const opponentPlayers = players.filter(
+        (player) => player.socketID !== socketID
+      );
+      setPlayers(opponentPlayers);
     }
 
     socket.emit("get playercount", lobbyNr);
     socket.on("display current playercount", handleCurrentPlayerCount);
 
-    socket.emit("get opponent players", lobbyNr, socketID);
-    socket.on("display opponent players", handleDisplayPlayers);
+    socket.emit("get players", lobbyNr, socketID);
+    socket.on("display players", handleDisplayPlayers);
 
     socket.emit("player joined", playerName, socketID);
     socket.on("broadcast join", (player) => {
@@ -76,6 +78,7 @@ export default function Game() {
     }
   );
 
+  //Still saving this for the case of 8 players
   // const renderOpponentCardGrids = () => {
   //   // if (playerCount === 8) {
   //   //   return (
@@ -108,8 +111,6 @@ export default function Game() {
 
       <main className={styles.viewContainer}>
         <Logo size="small" />
-        {/* Just to check if the actual count is transmitted */}
-        {playerCount}
         <div className={styles.pageElements}>
           <aside className={styles.topBar}>
             <ExitBtn onClick={handleExitBtnClick} />
@@ -126,7 +127,9 @@ export default function Game() {
           </aside>
           <div className={styles.gameElements8Player}>
             <div className={styles.opponents}>{opponentCardGrids}</div>
-            <div className={styles.playerCardGrid}>{/* <CardGrid /> */}</div>
+            <div className={styles.playerCardGrid}>
+              <CardGrid />
+            </div>
           </div>
         </div>
       </main>

--- a/pages/lobbies.tsx
+++ b/pages/lobbies.tsx
@@ -66,14 +66,14 @@ export default function Lobbies() {
               </a>
             </Link>
             <ul className={styles.list}>
-              {lobbyItems.map((lobby) => {
+              {lobbyItems.map(({ lobbyNr, playerCount, lobbyIsFull }) => {
                 return (
                   <LobbyListItem
-                    key={lobby.lobbyNr}
-                    playerCount={lobby.playerCount}
-                    lobbyNr={lobby.lobbyNr}
-                    onClick={() => handleJoinBtnClick(lobby.lobbyNr)}
-                    lobbyIsFull={lobby.lobbyIsFull}
+                    key={lobbyNr}
+                    playerCount={playerCount}
+                    lobbyNr={lobbyNr}
+                    onClick={() => handleJoinBtnClick(lobbyNr)}
+                    lobbyIsFull={lobbyIsFull}
                   />
                 );
               })}

--- a/server/lib/gameTypes.ts
+++ b/server/lib/gameTypes.ts
@@ -26,6 +26,11 @@ export type Player = {
   roundScore: number[];
 };
 
+export type PlayerForCardGrid = Pick<
+  Player,
+  "name" | "cards" | "roundScore" | "socketID"
+>;
+
 export type PlayerScoreList = Pick<Player, "name" | "totalScore">;
 
 export type Card = {

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -5,6 +5,7 @@ import {
   GameForLobby,
   Player,
   PlayerScoreList,
+  PlayerForCardGrid,
 } from "./gameTypes";
 
 const games: GamesType = {};
@@ -125,4 +126,26 @@ export function getRoundNr(lobbyNr: number): number {
 
 export function getPlayerCount(lobbyNr: number): number {
   return games[lobbyNr].playerCount;
+}
+
+export function getOpponentPlayers(
+  lobbyNr: number,
+  socketID: string
+): PlayerForCardGrid[] {
+  const allPlayers = games[lobbyNr].players.map((player) => {
+    return {
+      name: player.name,
+      cards: player.cards,
+      roundScore: player.roundScore,
+      socketID: player.socketID,
+    };
+  });
+
+  const indexOfSelf = allPlayers
+    .map((player) => player.socketID)
+    .indexOf(socketID);
+
+  const opponentPlayers = allPlayers.splice(indexOfSelf, 1);
+
+  return opponentPlayers;
 }

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -140,12 +140,9 @@ export function getOpponentPlayers(
       socketID: player.socketID,
     };
   });
-
-  const indexOfSelf = allPlayers
-    .map((player) => player.socketID)
-    .indexOf(socketID);
-
-  const opponentPlayers = allPlayers.splice(indexOfSelf, 1);
-
+  const opponentPlayers = allPlayers.filter(
+    (player) => player.socketID !== socketID
+  );
+  console.log("opponents are ", opponentPlayers);
   return opponentPlayers;
 }

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -128,11 +128,8 @@ export function getPlayerCount(lobbyNr: number): number {
   return games[lobbyNr].playerCount;
 }
 
-export function getOpponentPlayers(
-  lobbyNr: number,
-  socketID: string
-): PlayerForCardGrid[] {
-  const allPlayers = games[lobbyNr].players.map((player) => {
+export function getPlayersInLobby(lobbyNr: number): PlayerForCardGrid[] {
+  return games[lobbyNr].players.map((player) => {
     return {
       name: player.name,
       cards: player.cards,
@@ -140,9 +137,4 @@ export function getOpponentPlayers(
       socketID: player.socketID,
     };
   });
-  const opponentPlayers = allPlayers.filter(
-    (player) => player.socketID !== socketID
-  );
-  console.log("opponents are ", opponentPlayers);
-  return opponentPlayers;
 }

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -3,8 +3,8 @@ import {
   createGame,
   getGame,
   getGamesForLobby,
-  getOpponentPlayers,
   getPlayerCount,
+  getPlayersInLobby,
   getRoundNr,
   getTotalScores,
   joinGame,
@@ -28,15 +28,8 @@ function broadcastTotalScoresToLobby(io, lobbyNr: number): void {
   io.to(`lobby${lobbyNr}`).emit("display scores", getTotalScores(lobbyNr));
 }
 
-function broadcastOpponentsToLobby(
-  io,
-  lobbyNr: number,
-  socketID: string
-): void {
-  io.to(`lobby${lobbyNr}`).emit(
-    "display opponent players",
-    getOpponentPlayers(lobbyNr, socketID)
-  );
+function broadcastPlayersToLobby(io, lobbyNr: number): void {
+  io.to(`lobby${lobbyNr}`).emit("display players", getPlayersInLobby(lobbyNr));
 }
 
 export function listenSocket(server): void {
@@ -50,11 +43,11 @@ export function listenSocket(server): void {
       console.log(socket.id + " disconnected");
       await leaveGame(socket.id);
       try {
-        //Hier liegt evtl. das Problem - ich muss die lobbyNr irgendwo anders herbekommen
+        //Disconnect Problem: ich muss die lobbyNr irgendwo anders herbekommen
         const lobbyNr = (await getGame(socket.id)).lobbyNr;
         broadcastTotalScoresToLobby(io, lobbyNr);
         broadcastPlayerCountToLobby(io, lobbyNr);
-        broadcastOpponentsToLobby(io, lobbyNr, socket.id);
+        broadcastPlayersToLobby(io, lobbyNr);
         broadcastListGamesUpdate();
       } catch (error) {
         console.log(error);
@@ -67,7 +60,7 @@ export function listenSocket(server): void {
       broadcastListGamesUpdate();
       broadcastTotalScoresToLobby(io, lobbyNr);
       broadcastPlayerCountToLobby(io, lobbyNr);
-      broadcastOpponentsToLobby(io, lobbyNr, socketID);
+      broadcastPlayersToLobby(io, lobbyNr);
     });
 
     socket.on("get list of games", () => {
@@ -86,8 +79,8 @@ export function listenSocket(server): void {
       broadcastPlayerCountToLobby(io, lobbyNr);
     });
 
-    socket.on("get opponent players", (lobbyNr: number, socketID: string) => {
-      broadcastOpponentsToLobby(io, lobbyNr, socketID);
+    socket.on("get players", (lobbyNr: number) => {
+      broadcastPlayersToLobby(io, lobbyNr);
     });
 
     socket.on("create game", (playerName: string, socketID: string) => {
@@ -97,7 +90,7 @@ export function listenSocket(server): void {
       socket.emit("pass lobbynr", lobbyNr);
       broadcastPlayerCountToLobby(io, lobbyNr);
       broadcastTotalScoresToLobby(io, lobbyNr);
-      broadcastOpponentsToLobby(io, lobbyNr, socketID);
+      broadcastPlayersToLobby(io, lobbyNr);
       broadcastListGamesUpdate();
       lobbyNr++;
     });
@@ -109,7 +102,7 @@ export function listenSocket(server): void {
         joinGame(lobbyNr, playerName, socketID);
         broadcastPlayerCountToLobby(io, lobbyNr);
         broadcastTotalScoresToLobby(io, lobbyNr);
-        broadcastOpponentsToLobby(io, lobbyNr, socketID);
+        broadcastPlayersToLobby(io, lobbyNr);
         broadcastListGamesUpdate();
       }
     );


### PR DESCRIPTION
- Destructure/remove some code
- Add getPlayersInLobby() on serverside
- Add socket events/emits on server- and clientside
- Add handleDisplayPlayers() on clientside, rendering every opponent's card grid except the players

This one wasn't all too easy. Thanks to @florianGierlichs and @j-toscani for their ideas 💯 

Need to add blank cards when first rendering the opponent cardgrids, also need to render the current players cards and status to the big cardgrid.

Deployment: https://sisu-pipelin-rendergrid-gsucqt.herokuapp.com/
Part of #50 