### PR TITLE
🐛 Fix errors on player disconnect

### DIFF
--- a/components/button/ExitBtn.tsx
+++ b/components/button/ExitBtn.tsx
@@ -1,5 +1,5 @@
 import styles from "./Button.module.css";
-import { ButtonProps } from "./types";
+import type { ButtonProps } from "./types";
 
 function ExitBtn({ onClick }: ButtonProps) {
   return (

--- a/components/gameboard/CardGrid.module.css
+++ b/components/gameboard/CardGrid.module.css
@@ -104,6 +104,7 @@
   padding: 0.6em;
   box-shadow: var(--shadow);
   border-radius: 5px;
+  min-width: 180px;
 }
 
 .oppCardGrid img {

--- a/components/gameboard/CardGrid.tsx
+++ b/components/gameboard/CardGrid.tsx
@@ -1,5 +1,5 @@
 import styles from "./CardGrid.module.css";
-import { CardGridProps } from "./OpponentCardGrid";
+import type { CardGridProps } from "./OpponentCardGrid";
 
 function CardGrid({ onClick, cards, name, roundScore }: CardGridProps) {
   const createPlayerCardGrid = cards.map((card) => (

--- a/components/gameboard/DiscardPile.tsx
+++ b/components/gameboard/DiscardPile.tsx
@@ -7,7 +7,6 @@ function DiscardPile({ onClick, card }: DiscardPileProps) {
       <section className={styles.container}>
         <h2 className={styles.discardHeadline}>Discard Pile</h2>
         <img
-          key={card ? card.value : ""}
           src={card ? card.imgSrc : "/cards/blank.png"}
           className={styles.card}
           onClick={() => onClick}

--- a/components/gameboard/DiscardPile.tsx
+++ b/components/gameboard/DiscardPile.tsx
@@ -1,5 +1,5 @@
 import styles from "./Piles.module.css";
-import { DiscardPileProps } from "./types";
+import type { DiscardPileProps } from "./types";
 
 function DiscardPile({ onClick, card }: DiscardPileProps) {
   return (

--- a/components/gameboard/DrawPile.tsx
+++ b/components/gameboard/DrawPile.tsx
@@ -1,5 +1,5 @@
 import styles from "./Piles.module.css";
-import { PileProps } from "./types";
+import type { PileProps } from "./types";
 
 function DrawPile({ onClick }: PileProps) {
   return (

--- a/components/gameboard/OpponentCardGrid.tsx
+++ b/components/gameboard/OpponentCardGrid.tsx
@@ -1,5 +1,5 @@
 import { MouseEventHandler } from "react";
-import { Card } from "../../server/lib/gameTypes";
+import type { Card } from "../../server/lib/gameTypes";
 import styles from "./CardGrid.module.css";
 
 export type CardGridProps = {

--- a/components/gameboard/RoundCounter.tsx
+++ b/components/gameboard/RoundCounter.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState } from "react";
 import { SocketContext } from "../../contexts/SocketContext";
 import { getLobbyNr } from "../../lib/functions";
 import styles from "./MiscElements.module.css";
-import { RoundCounterProps } from "./types";
+import type { RoundCounterProps } from "./types";
 
 function RoundCounter() {
   const { socket } = useContext(SocketContext);

--- a/components/gameboard/Statusbar.tsx
+++ b/components/gameboard/Statusbar.tsx
@@ -1,5 +1,5 @@
 import styles from "./MiscElements.module.css";
-import { StatusbarProps } from "./types";
+import type { StatusbarProps } from "./types";
 
 function Statusbar({ statusMessage }: StatusbarProps) {
   return (

--- a/components/gameboard/TotalScore.tsx
+++ b/components/gameboard/TotalScore.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { SocketContext } from "../../contexts/SocketContext";
 import { getLobbyNr } from "../../lib/functions";
-import { PlayerScoreList } from "../../server/lib/gameTypes";
+import type { PlayerScoreList } from "../../server/lib/gameTypes";
 import styles from "./Score.module.css";
 type ScoreListProps = {
   name: string;

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -14,7 +14,7 @@ import { SocketContext } from "../contexts/SocketContext";
 import { useContext, useEffect, useState } from "react";
 import { getLobbyNr, getSocketID } from "../lib/functions";
 import { useRouter } from "next/router";
-import { Card, PlayerForCardGrid } from "../server/lib/gameTypes";
+import type { Card, PlayerForCardGrid } from "../server/lib/gameTypes";
 import { generateBlankCards } from "../server/lib/cards";
 
 export default function Game() {

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -95,29 +95,14 @@ export default function Game() {
     }
   );
 
-  //Still saving this for the case of 8 players
-  // const renderOpponentCardGrids = () => {
-  //   // if (playerCount === 8) {
-  //   //   return (
-  //   //     <div className={styles.opponents}>
-  //   //       <div className={styles.op8row}>
-  //   //         <OpponentCardGrid />
-  //   //         <OpponentCardGrid />
-  //   //       </div>
-  //   //       <OpponentCardGrid />
-  //   //       <OpponentCardGrid />
-  //   //       <OpponentCardGrid />
-  //   //       <OpponentCardGrid />
-  //   //       <div className={styles.op8row}>
-  //   //         <OpponentCardGrid />
-  //   //         <OpponentCardGrid />
-  //   //       </div>
-  //   //     </div>
-  //   //   );
-  //   // }
-
-  //   return opponentCardGrids;
-  // };
+  const opponentsLayout =
+    playerCount <= 7
+      ? {
+          gridTemplateColumns: `repeat(${playerCount - 1}, 1fr)`,
+        }
+      : {
+          gridTemplateColumns: `repeat(6, 1fr)`,
+        };
 
   return (
     <>
@@ -148,8 +133,10 @@ export default function Game() {
             />
           </aside>
           <div className={styles.gameElements8Player}>
-            <div className={styles.opponents}>{opponentCardGrids}</div>
-            <div className={styles.playerCardGrid}>
+            <div className={styles.opponents} style={opponentsLayout}>
+              {opponentCardGrids}
+            </div>
+            <div className={playerCount === 8 && styles.playerCardGrid}>
               {player && (
                 <CardGrid
                   cards={gameHasStarted ? player.cards : blankCards}

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -1,5 +1,5 @@
 import { generateCards } from "./cards";
-import {
+import type {
   Game,
   GamesType,
   GameForLobby,

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -159,6 +159,6 @@ export function getDiscardPile(lobbyNr: number): Card {
   return discardpile[discardpile.length - 1];
 }
 
-export function getNumberOfGames() {
-  return games[[].length];
-}
+// export function getNumberOfGames(): number {
+//   return games[[0].length];
+// }

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -158,3 +158,7 @@ export function getDiscardPile(lobbyNr: number): Card {
   const discardpile = getGameByLobby(lobbyNr).discardPileCards;
   return discardpile[discardpile.length - 1];
 }
+
+export function getNumberOfGames() {
+  return games[[].length];
+}

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -6,7 +6,6 @@ import {
   getGame,
   getGameByLobby,
   getGamesForLobby,
-  getNumberOfGames,
   getPlayer,
   getPlayerCount,
   getPlayersInLobby,

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -58,9 +58,6 @@ export function listenSocket(server): void {
 
     socket.on("disconnecting", async () => {
       console.log(socket.id, " disconnecting");
-      // check if socket is in a room
-      // console.log(socket.rooms.has("lobby1"));
-      // console.log(socket.rooms.size);
       for (let i = 1; i <= 20; i++) {
         if (socket.rooms.has(`lobby${i}`)) {
           console.log(i, true);

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -6,6 +6,7 @@ import {
   getGame,
   getGameByLobby,
   getGamesForLobby,
+  getNumberOfGames,
   getPlayer,
   getPlayerCount,
   getPlayersInLobby,
@@ -53,16 +54,26 @@ export function listenSocket(server): void {
 
     socket.on("disconnect", async () => {
       console.log(socket.id + " disconnected");
-      await leaveGame(socket.id);
-      try {
-        //Disconnect Problem: ich muss die lobbyNr irgendwo anders herbekommen
-        const lobbyNr = (await getGame(socket.id)).lobbyNr;
-        broadcastTotalScoresToLobby(io, lobbyNr);
-        broadcastPlayerCountToLobby(io, lobbyNr);
-        broadcastPlayersToLobby(io, lobbyNr);
-        broadcastListGamesUpdate();
-      } catch (error) {
-        console.log(error);
+    });
+
+    socket.on("disconnecting", async () => {
+      console.log(socket.id, " disconnecting");
+      // check if socket is in a room
+      // console.log(socket.rooms.has("lobby1"));
+      // console.log(socket.rooms.size);
+      for (let i = 1; i <= 20; i++) {
+        if (socket.rooms.has(`lobby${i}`)) {
+          console.log(i, true);
+          const lobbyNr = (await getGame(socket.id)).lobbyNr;
+          await leaveGame(socket.id);
+          broadcastTotalScoresToLobby(io, lobbyNr);
+          broadcastPlayerCountToLobby(io, lobbyNr);
+          broadcastPlayersToLobby(io, lobbyNr);
+          broadcastListGamesUpdate();
+          return;
+        } else {
+          console.log(i, false);
+        }
       }
     });
 

--- a/styles/Game.module.css
+++ b/styles/Game.module.css
@@ -29,7 +29,7 @@
   grid-template-columns: 80% 20%;
   grid-template-rows: auto 1fr;
   align-items: start;
-  column-gap: 2em;
+  column-gap: 1em;
   width: 100%;
   grid-template-areas:
     "topbar sidebar"
@@ -49,6 +49,8 @@
   justify-items: center;
   align-items: start;
   column-gap: 1em;
+  row-gap: 1.5em;
+  min-height: 230px;
 }
 
 .op8row {

--- a/styles/Lobbies.module.css
+++ b/styles/Lobbies.module.css
@@ -17,6 +17,7 @@
   display: grid;
   grid-auto-flow: column;
   column-gap: 3em;
+  min-width: 800px;
 }
 
 .list {


### PR DESCRIPTION
Previously the gamestate wasn't changed when a player left a game by closing the tab/browser.
Also errors occured in the server log when a player closed the tab/browser while not being in a game

It's fixed for now, but limits the lobbies to 20.
Above 20 lobbies the error will occur again.

In order to fix that, I need to figure out how to get the amount of Lobbies currently created.

Deployment:
Fixes #60 in part