### PR TITLE
💄 Make lobbylist scrollable

### DIFF
--- a/styles/Lobbies.module.css
+++ b/styles/Lobbies.module.css
@@ -13,7 +13,7 @@
 }
 
 .pageItems {
-  margin-top: 1.5em;
+  margin-top: 1em;
   display: grid;
   grid-auto-flow: column;
   column-gap: 3em;
@@ -22,7 +22,9 @@
 
 .list {
   margin: 0;
-  padding: 0;
+  padding: 0 1em 0 0;
+  overflow-y: auto;
+  max-height: 18em;
 }
 .list li {
   margin-bottom: 1em;

--- a/styles/Lobbies.module.css
+++ b/styles/Lobbies.module.css
@@ -25,6 +25,7 @@
   padding: 0 1em 0 0;
   overflow-y: auto;
   max-height: 18em;
+  min-height: 18em;
 }
 .list li {
   margin-bottom: 1em;


### PR DESCRIPTION
Lobbylist on Lobbies page is now scrollable if too much lobbies exist.
This also fixes layoutshifts.

Deployment:
Fixes #47