### PR TITLE
✨ Add check if 2 cards are revealed on player cardgrid

### DIFF
--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -29,6 +29,7 @@ export default function Game() {
   const [player, setPlayer] = useState<PlayerForCardGrid>(null);
   const [gameHasStarted, setGameHasStarted] = useState<boolean>(false);
   const [discardPileCard, setDiscardPileCard] = useState<Card>(null);
+  const [roundStart, setRoundStart] = useState<boolean>(false);
 
   useEffect(() => {
     if (!socket || !lobbyNr) {
@@ -83,7 +84,13 @@ export default function Game() {
   };
 
   const handleCardGridClick = (index: number) => {
-    socket.emit("cardgrid click", socket.id, lobbyNr, index);
+    if (gameHasStarted) {
+      socket.emit("cardgrid click", socket.id, lobbyNr, index);
+      socket.emit("check 2 cards revealed", socket.id, lobbyNr);
+      socket.on("2 cards revealed", () => {
+        setRoundStart(true);
+      });
+    }
   };
 
   const opponentCardGrids = opponentPlayers.map(
@@ -146,7 +153,13 @@ export default function Game() {
                   cards={gameHasStarted ? player.cards : blankCards}
                   name={player.name}
                   roundScore={player.roundScore}
-                  onClick={handleCardGridClick}
+                  onClick={
+                    !roundStart
+                      ? handleCardGridClick
+                      : () => {
+                          return;
+                        }
+                  }
                 />
               )}
             </div>

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -207,3 +207,17 @@ export async function calculateRoundScore(socketID: string, lobbyNr: number) {
 
   player.roundScore[roundNr - 1] = roundScore;
 }
+
+export async function checkIfTwoCardsAreRevealed(
+  socketID: string
+): Promise<boolean> {
+  const player = await getPlayer(socketID);
+  const revealedCards = player.cards.filter((card) => card.hidden === false);
+
+  console.log(revealedCards);
+  if (revealedCards.length === 2) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -3,6 +3,7 @@ import {
   calculateRoundScore,
   cardGridClick,
   checkAllPlayersReady,
+  checkIfTwoCardsAreRevealed,
   createGame,
   dealCardsToPlayers,
   getDiscardPile,
@@ -94,7 +95,7 @@ export function listenSocket(server): void {
     });
 
     socket.on("get rounds to display", (lobbyNr: number) => {
-      socket.emit("display rounds", getRoundNr(lobbyNr));
+      io.to(`lobby${lobbyNr}`).emit("display rounds", getRoundNr(lobbyNr));
     });
 
     socket.on("get playercount", (lobbyNr: number) => {
@@ -155,6 +156,12 @@ export function listenSocket(server): void {
       await cardGridClick(socketID, index);
       await calculateRoundScore(socketID, lobbyNr);
       broadcastPlayersToLobby(io, lobbyNr);
+    });
+
+    socket.on("check 2 cards revealed", async (socketID, lobbyNr) => {
+      if (await checkIfTwoCardsAreRevealed(socketID)) {
+        io.to(`lobby${lobbyNr}`).emit("2 cards revealed", true);
+      }
     });
   });
 }


### PR DESCRIPTION
- Upon clicking a card a check will return a `true` if two cards are revealed
- If two cards are revealed, the player can't reveal any more cards

I'm not too sure right now about how I will implement the rounds and turns of each player, need to figure this out as it will be important for the next steps.

Next I'll have to add a check if all players in a game have revealed two cards.

Deployment: https://sisu-pipelin-revealcard-jdvmr4.herokuapp.com/
Fixes parts of #73