### PR TITLE
✨ Add socket events for clicking 'Keep'

### DIFF
--- a/components/button/Button.module.css
+++ b/components/button/Button.module.css
@@ -21,6 +21,7 @@
     ),
     linear-gradient(var(--placeholder-color), var(--placeholder-color));
   color: var(--placeholder-color);
+  cursor: default;
 }
 
 .btn:hover {

--- a/components/gameboard/CardGrid.tsx
+++ b/components/gameboard/CardGrid.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState } from "react";
 import { SocketContext } from "../../contexts/SocketContext";
 import { getLobbyNr } from "../../lib/functions";
+import { phase } from "../../server/lib/turnPhases";
 import styles from "./CardGrid.module.css";
 import type { PlayerCardGridProps } from "./OpponentCardGrid";
 
@@ -33,18 +34,18 @@ function CardGrid({
     }
     if (roundStart) {
       switch (turnPhase) {
-        case "drawDecision":
+        case phase.DRAWDECISION:
           return;
-        case "discardPileDecision":
+        case phase.DISCARDPILEDECISION:
           socket.emit("DISCARDPILE: replace card", socket.id, lobbyNr, index);
           break;
-        case "discardPileReplaceOpen":
-          alert("dpo");
+        case phase.DRAWPILEKEEP:
+          socket.emit("DRAWPILE: replace card", socket.id, lobbyNr, index);
           break;
         case "discardPileReplaceHidden":
           alert("dprh");
           break;
-        case "waitTurn":
+        case phase.WAITTURN:
           return;
         default:
           return;
@@ -54,9 +55,11 @@ function CardGrid({
 
   function cardStyle() {
     switch (turnPhase) {
-      case "drawDecision":
+      case phase.DRAWDECISION:
         return notClickable;
-      case "waitTurn":
+      case phase.WAITTURN:
+        return notClickable;
+      case phase.DRAWPILEDECISION:
         return notClickable;
       case "discardPileDecision":
         return styles.card;

--- a/components/gameboard/DrawPile.tsx
+++ b/components/gameboard/DrawPile.tsx
@@ -14,7 +14,7 @@ function DrawPile({ turnPhase }: DrawPileProps) {
     switch (turnPhase) {
       case phase.DRAWDECISION:
         socket.emit("DRAWDECISION: click drawpile", socket.id, lobbyNr);
-        socket.emit("get drawpilecard", lobbyNr);
+        socket.emit("get new drawpilecard", lobbyNr);
         break;
       case "waitTurn":
         return;

--- a/components/gameboard/DrawPile.tsx
+++ b/components/gameboard/DrawPile.tsx
@@ -14,6 +14,7 @@ function DrawPile({ turnPhase }: DrawPileProps) {
     switch (turnPhase) {
       case phase.DRAWDECISION:
         socket.emit("DRAWDECISION: click drawpile", socket.id, lobbyNr);
+        socket.emit("get drawpilecard", lobbyNr);
         break;
       case "waitTurn":
         return;

--- a/components/gameboard/DrawPilePrompt.module.css
+++ b/components/gameboard/DrawPilePrompt.module.css
@@ -2,6 +2,7 @@
   display: grid;
   row-gap: 1.5em;
   justify-items: center;
+  min-width: 16em;
 }
 
 .buttons {

--- a/components/gameboard/DrawPilePrompt.tsx
+++ b/components/gameboard/DrawPilePrompt.tsx
@@ -23,7 +23,10 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
 
     switch (turnPhase) {
       case phase.DRAWPILEDECISION:
-        socket.emit("get drawpilecard", lobbyNr);
+        socket.emit("get new drawpilecard", lobbyNr);
+        break;
+      default:
+        socket.emit("get current drawpilecard", lobbyNr);
         break;
     }
 
@@ -31,16 +34,21 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
       setDrawPileCard(card);
     }
 
-    socket.on("display drawpilecard", (card) => {
+    socket.on("display new drawpilecard", (card) => {
       if (!card) {
-        socket.emit("get drawpilecard", lobbyNr);
+        socket.emit("get new drawpilecard", lobbyNr);
       } else {
         handleDisplayDrawPileCard(card);
       }
     });
 
+    socket.on("display current drawpilecard", (card) => {
+      handleDisplayDrawPileCard(card);
+    });
+
     return () => {
-      socket.off("display drawpilecard");
+      socket.off("display new drawpilecard");
+      socket.off("display current drawpilecard");
     };
   }, [socket, lobbyNr]);
 

--- a/components/gameboard/DrawPilePrompt.tsx
+++ b/components/gameboard/DrawPilePrompt.tsx
@@ -49,8 +49,6 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
       case phase.DRAWPILEDECISION:
         socket.emit("DRAWPILEDECISION: click keep", socket.id, lobbyNr);
         break;
-      case phase.WAITTURNDRAWPILEDECISION:
-        return;
       case phase.WAITTURN:
         return;
       default:
@@ -63,8 +61,6 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
       case phase.DRAWPILEDECISION:
         socket.emit("DRAWPILEDECISION: click discard", socket.id, lobbyNr);
         break;
-      case phase.WAITTURNDRAWPILEDECISION:
-        return;
       case phase.WAITTURN:
         return;
       default:
@@ -74,10 +70,12 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
 
   return (
     <div className={styles.container}>
-      <div className={styles.buttons}>
-        <KeepBtn handleClick={handleKeepClick} />
-        <DiscardBtn handleClick={handleDiscardClick} />
-      </div>
+      {turnPhase === phase.DRAWPILEDECISION && (
+        <div className={styles.buttons}>
+          <KeepBtn handleClick={handleKeepClick} />
+          <DiscardBtn handleClick={handleDiscardClick} />
+        </div>
+      )}
       <img
         src={drawPileCard ? drawPileCard.imgSrc : "/cards/blank.png"}
         className={styles.card}

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -21,7 +21,6 @@ import type {
 } from "../server/lib/gameTypes";
 import { generateBlankCards } from "../server/lib/cards";
 import DrawPilePrompt from "../components/gameboard/DrawPilePrompt";
-import { phase } from "../server/lib/turnPhases";
 
 export default function Game() {
   const { socket } = useContext(SocketContext);
@@ -158,24 +157,23 @@ export default function Game() {
             </div>
             <div
               className={
-                turnPhase === phase.DRAWPILEDECISION &&
-                styles.playerCardGridDrawPilePrompt
+                playerCount === 8
+                  ? styles.playerCardGrid8
+                  : styles.playerCardGrid
               }
             >
-              <div className={playerCount === 8 && styles.playerCardGrid}>
-                {player && (
-                  <CardGrid
-                    cards={gameHasStarted ? player.cards : blankCards}
-                    name={player.name}
-                    roundScore={player.roundScore}
-                    gameHasStarted={gameHasStarted}
-                    turnPhase={turnPhase}
-                  />
-                )}
-              </div>
-              {turnPhase === phase.DRAWPILEDECISION && (
-                <DrawPilePrompt turnPhase={turnPhase} />
+              {player && (
+                <CardGrid
+                  cards={gameHasStarted ? player.cards : blankCards}
+                  name={player.name}
+                  roundScore={player.roundScore}
+                  gameHasStarted={gameHasStarted}
+                  turnPhase={turnPhase}
+                />
               )}
+            </div>
+            <div className={styles.playerCardGridDrawPilePrompt}>
+              <DrawPilePrompt turnPhase={turnPhase} />
             </div>
           </div>
         </div>

--- a/server/lib/broadcasts.ts
+++ b/server/lib/broadcasts.ts
@@ -1,12 +1,12 @@
 import {
   getActivePlayer,
   getDiscardPile,
+  getDrawPileCard,
   getFirstActivePlayer,
   getGameByLobby,
   getGamesForLobby,
   getPlayerCount,
   getPlayersInLobby,
-  getRandomCard,
   getTotalScores,
 } from "./games";
 import { status } from "./statusMessages";
@@ -40,7 +40,10 @@ export function broadcastDiscardPileToLobby(io, lobbyNr: number): void {
 }
 
 export function broadcastDrawPileCardToLobby(io, lobbyNr: number): void {
-  io.to(`lobby${lobbyNr}`).emit("display drawpilecard", getRandomCard(lobbyNr));
+  io.to(`lobby${lobbyNr}`).emit(
+    "display drawpilecard",
+    getDrawPileCard(lobbyNr)
+  );
 }
 
 export async function broadcastFirstActivePlayerToLobby(

--- a/server/lib/broadcasts.ts
+++ b/server/lib/broadcasts.ts
@@ -1,10 +1,11 @@
 import {
   getActivePlayer,
+  getCurrentDrawPileCard,
   getDiscardPile,
-  getDrawPileCard,
   getFirstActivePlayer,
   getGameByLobby,
   getGamesForLobby,
+  getNewDrawPileCard,
   getPlayerCount,
   getPlayersInLobby,
   getTotalScores,
@@ -39,10 +40,17 @@ export function broadcastDiscardPileToLobby(io, lobbyNr: number): void {
   io.to(`lobby${lobbyNr}`).emit("display discardpile", getDiscardPile(lobbyNr));
 }
 
-export function broadcastDrawPileCardToLobby(io, lobbyNr: number): void {
+export function broadcastNewDrawPileCardToLobby(io, lobbyNr: number): void {
   io.to(`lobby${lobbyNr}`).emit(
-    "display drawpilecard",
-    getDrawPileCard(lobbyNr)
+    "display new drawpilecard",
+    getNewDrawPileCard(lobbyNr)
+  );
+}
+
+export function broadcastCurrentDrawPileCardToLobby(io, lobbyNr: number): void {
+  io.to(`lobby${lobbyNr}`).emit(
+    "display current drawpilecard",
+    getCurrentDrawPileCard(lobbyNr)
   );
 }
 

--- a/server/lib/gameTypes.ts
+++ b/server/lib/gameTypes.ts
@@ -7,6 +7,7 @@ export type Game = {
   activePlayerIndex: number;
   players: Player[];
   drawPileCards: Card[];
+  tempDrawPileCard: Card;
   discardPileCards: Card[];
 };
 

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -348,6 +348,8 @@ export async function setNextActivePlayer(socketID: string): Promise<void> {
 
 export function getDrawPileCard(lobbyNr: number): Card {
   const randomCard = getRandomCard(lobbyNr);
+  randomCard.hidden = false;
   games[lobbyNr].tempDrawPileCard = randomCard;
+  console.log(games[lobbyNr].tempDrawPileCard);
   return randomCard;
 }

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -195,7 +195,7 @@ export async function cardRevealClick(
   (await getPlayer(socketID)).cards[index].hidden = false;
 }
 
-export async function cardReplaceWithDiscardPileClick(
+export async function cardReplaceDiscardPileClick(
   socketID: string,
   lobbyNr: number,
   index: number
@@ -224,12 +224,25 @@ export async function cardReplaceWithDiscardPileClick(
     playerCards.splice(index + 1, 1);
   };
   replaceClickedCardWithDiscardPileCard();
+}
 
-  console.log("playercards", JSON.stringify(playerCards, null, 4));
-  console.log(
-    "discardpile",
-    JSON.stringify(games[lobbyNr].discardPileCards, null, 4)
-  );
+export async function cardReplaceDrawPileKeepClick(
+  socketID: string,
+  lobbyNr: number,
+  index: number
+): Promise<void> {
+  const playerCards = (await getPlayer(socketID)).cards;
+  const clickedCard = (await getPlayer(socketID)).cards[index];
+  const drawPileCard = games[lobbyNr].tempDrawPileCard;
+
+  const replaceClickedCardWithDrawPileCard = () => {
+    clickedCard.hidden = false;
+
+    const replacedCard = playerCards.splice(index, 1, drawPileCard);
+    games[lobbyNr].discardPileCards.push(replacedCard[0]);
+    games[lobbyNr].tempDrawPileCard = null;
+  };
+  replaceClickedCardWithDrawPileCard();
 }
 
 export async function checkCardsVerticalRow(socketID: string): Promise<void> {
@@ -346,10 +359,20 @@ export async function setNextActivePlayer(socketID: string): Promise<void> {
   }
 }
 
-export function getDrawPileCard(lobbyNr: number): Card {
+export function getNewDrawPileCard(lobbyNr: number): Card {
   const randomCard = getRandomCard(lobbyNr);
   randomCard.hidden = false;
   games[lobbyNr].tempDrawPileCard = randomCard;
   console.log(games[lobbyNr].tempDrawPileCard);
   return randomCard;
+}
+
+export function getCurrentDrawPileCard(lobbyNr: number): Card {
+  return games[lobbyNr].tempDrawPileCard;
+}
+
+export function discardCurrentDrawPileCard(lobbyNr: number): void {
+  const drawPileCard = games[lobbyNr].tempDrawPileCard;
+  games[lobbyNr].discardPileCards.push(drawPileCard);
+  games[lobbyNr].tempDrawPileCard = null;
 }

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -36,6 +36,7 @@ export function createGame(
       },
     ],
     drawPileCards: generateCards(),
+    tempDrawPileCard: null,
     discardPileCards: [],
   };
   //commented out for now
@@ -343,4 +344,10 @@ export async function setNextActivePlayer(socketID: string): Promise<void> {
   } else {
     currentGame.activePlayerIndex = 0;
   }
+}
+
+export function getDrawPileCard(lobbyNr: number): Card {
+  const randomCard = getRandomCard(lobbyNr);
+  games[lobbyNr].tempDrawPileCard = randomCard;
+  return randomCard;
 }

--- a/server/lib/statusMessages.ts
+++ b/server/lib/statusMessages.ts
@@ -9,6 +9,8 @@ export const status = {
   DRAWPILEDECISION: "Do you want to keep or discard your drawn card?",
   DRAWPILEDISCARD:
     "Card added to discard pile. Reveal a hidden card on your grid",
+  DRAWPILEDISCARDINVALID:
+    "Invalid card clicked. Please reveal a hidden card on your grid",
   DRAWDISCARDPILEKEEP: "Replace open or hidden card on your grid",
   DRAWDISCARDPILEKEEPOPEN:
     "Replaced open card. Replaced card added to discard pile",

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -231,5 +231,23 @@ export function listenSocket(server): void {
         // check 12 cards revealed
       }
     );
+
+    socket.on(
+      "DRAWPILEDECISION: click keep",
+      async (socketID: string, lobbyNr: number) => {
+        await broadcastStatusToActivePlayer(
+          io,
+          socketID,
+          lobbyNr,
+          status.DRAWDISCARDPILEKEEP
+        );
+        await broadcastTurnPhaseToActivePlayer(
+          io,
+          socketID,
+          lobbyNr,
+          phase.DRAWPILEKEEP
+        );
+      }
+    );
   });
 }

--- a/styles/Game.module.css
+++ b/styles/Game.module.css
@@ -41,7 +41,7 @@
   justify-items: center;
   grid-area: game;
   grid-template-rows: auto auto;
-  grid-template-columns: auto auto;
+  grid-template-columns: auto 30%;
   grid-template-areas: "opp opp";
 }
 
@@ -65,6 +65,7 @@
 
 .playerCardGrid {
   justify-self: end;
+  padding-right: 3em;
 }
 
 .playerCardGrid8 {

--- a/styles/Game.module.css
+++ b/styles/Game.module.css
@@ -40,6 +40,9 @@
   display: grid;
   justify-items: center;
   grid-area: game;
+  grid-template-rows: auto auto;
+  grid-template-columns: auto auto;
+  grid-template-areas: "opp opp";
 }
 
 .opponents {
@@ -51,16 +54,20 @@
   column-gap: 1em;
   row-gap: 1.5em;
   min-height: 230px;
+  grid-area: opp;
 }
 
 .playerCardGridDrawPilePrompt {
   display: grid;
-  grid-auto-flow: column;
-  width: 100%;
-  justify-items: end;
+  justify-self: end;
   align-items: center;
 }
+
 .playerCardGrid {
+  justify-self: end;
+}
+
+.playerCardGrid8 {
   position: relative;
   bottom: 10em;
 }


### PR DESCRIPTION
- Add basic setup for the 'keep' event, when clicking the drawpile
- Change frontend layout to handle multiple layouts

This was really tiresome to do, because the frontend layout change was a bit nervewrecking.
My goal was, that the drawn card is shown to the waiting players aswell, but they shouldn't be able to see the decision-buttons.
Ran into multiple complications with conditional rendering and am still not really happy with the result.

Had to stop though, because this is too time consuming to get 100% right - will need to fix this at a later stage.

Deployment:
Kind of part of #79