### PR TITLE
✨ Add actions for replacing a card after clicking 'keep' button

### DIFF
--- a/components/button/Button.module.css
+++ b/components/button/Button.module.css
@@ -21,6 +21,7 @@
     ),
     linear-gradient(var(--placeholder-color), var(--placeholder-color));
   color: var(--placeholder-color);
+  cursor: default;
 }
 
 .btn:hover {

--- a/components/gameboard/CardGrid.tsx
+++ b/components/gameboard/CardGrid.tsx
@@ -72,8 +72,16 @@ function CardGrid({
     <img
       key={index}
       src={card && card.hidden ? "/cards/back.png" : card && card.imgSrc}
-      className={cardStyle()}
-      onClick={() => handleCardClick(index)}
+      className={
+        card.imgSrc !== "/cards/blank.png" ? cardStyle() : notClickable
+      }
+      onClick={
+        card.imgSrc !== "/cards/blank.png"
+          ? () => handleCardClick(index)
+          : () => {
+              return;
+            }
+      }
     />
   ));
 

--- a/components/gameboard/CardGrid.tsx
+++ b/components/gameboard/CardGrid.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState } from "react";
 import { SocketContext } from "../../contexts/SocketContext";
 import { getLobbyNr } from "../../lib/functions";
+import { Card } from "../../server/lib/gameTypes";
 import { phase } from "../../server/lib/turnPhases";
 import styles from "./CardGrid.module.css";
 import type { PlayerCardGridProps } from "./OpponentCardGrid";
@@ -18,7 +19,7 @@ function CardGrid({
 
   const notClickable = `${styles.card} ${styles.notClickable}`;
 
-  const handleCardClick = (index: number): void => {
+  const handleCardClick = (index: number, card: Card): void => {
     if (gameHasStarted && !roundStart) {
       socket.emit("cardgrid click", socket.id, lobbyNr, index);
       socket.emit(
@@ -42,8 +43,12 @@ function CardGrid({
         case phase.DRAWPILEKEEP:
           socket.emit("DRAWPILE: replace card", socket.id, lobbyNr, index);
           break;
-        case "discardPileReplaceHidden":
-          alert("dprh");
+        case phase.DRAWPILEDISCARD:
+          if (card.hidden === false) {
+            socket.emit("DRAWPILE: invalid reveal card", socket.id, lobbyNr);
+            return;
+          }
+          socket.emit("DRAWPILE: reveal card", socket.id, lobbyNr, index);
           break;
         case phase.WAITTURN:
           return;
@@ -77,7 +82,7 @@ function CardGrid({
       }
       onClick={
         card.imgSrc !== "/cards/blank.png"
-          ? () => handleCardClick(index)
+          ? () => handleCardClick(index, card)
           : () => {
               return;
             }

--- a/components/gameboard/DrawPile.tsx
+++ b/components/gameboard/DrawPile.tsx
@@ -14,7 +14,7 @@ function DrawPile({ turnPhase }: DrawPileProps) {
     switch (turnPhase) {
       case phase.DRAWDECISION:
         socket.emit("DRAWDECISION: click drawpile", socket.id, lobbyNr);
-        socket.emit("get drawpilecard", lobbyNr);
+        socket.emit("get new drawpilecard", lobbyNr);
         break;
       case "waitTurn":
         return;

--- a/components/gameboard/DrawPilePrompt.tsx
+++ b/components/gameboard/DrawPilePrompt.tsx
@@ -23,7 +23,10 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
 
     switch (turnPhase) {
       case phase.DRAWPILEDECISION:
-        socket.emit("get drawpilecard", lobbyNr);
+        socket.emit("get new drawpilecard", lobbyNr);
+        break;
+      default:
+        socket.emit("get current drawpilecard", lobbyNr);
         break;
     }
 
@@ -31,16 +34,21 @@ function DrawPilePrompt({ turnPhase }: DrawPilePrompt) {
       setDrawPileCard(card);
     }
 
-    socket.on("display drawpilecard", (card) => {
+    socket.on("display new drawpilecard", (card) => {
       if (!card) {
-        socket.emit("get drawpilecard", lobbyNr);
+        socket.emit("get new drawpilecard", lobbyNr);
       } else {
         handleDisplayDrawPileCard(card);
       }
     });
 
+    socket.on("display current drawpilecard", (card) => {
+      handleDisplayDrawPileCard(card);
+    });
+
     return () => {
-      socket.off("display drawpilecard");
+      socket.off("display new drawpilecard");
+      socket.off("display current drawpilecard");
     };
   }, [socket, lobbyNr]);
 

--- a/server/lib/broadcasts.ts
+++ b/server/lib/broadcasts.ts
@@ -1,10 +1,11 @@
 import {
   getActivePlayer,
+  getCurrentDrawPileCard,
   getDiscardPile,
-  getDrawPileCard,
   getFirstActivePlayer,
   getGameByLobby,
   getGamesForLobby,
+  getNewDrawPileCard,
   getPlayerCount,
   getPlayersInLobby,
   getTotalScores,
@@ -39,10 +40,17 @@ export function broadcastDiscardPileToLobby(io, lobbyNr: number): void {
   io.to(`lobby${lobbyNr}`).emit("display discardpile", getDiscardPile(lobbyNr));
 }
 
-export function broadcastDrawPileCardToLobby(io, lobbyNr: number): void {
+export function broadcastNewDrawPileCardToLobby(io, lobbyNr: number): void {
   io.to(`lobby${lobbyNr}`).emit(
-    "display drawpilecard",
-    getDrawPileCard(lobbyNr)
+    "display new drawpilecard",
+    getNewDrawPileCard(lobbyNr)
+  );
+}
+
+export function broadcastCurrentDrawPileCardToLobby(io, lobbyNr: number): void {
+  io.to(`lobby${lobbyNr}`).emit(
+    "display current drawpilecard",
+    getCurrentDrawPileCard(lobbyNr)
   );
 }
 

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -370,3 +370,9 @@ export function getNewDrawPileCard(lobbyNr: number): Card {
 export function getCurrentDrawPileCard(lobbyNr: number): Card {
   return games[lobbyNr].tempDrawPileCard;
 }
+
+export function discardCurrentDrawPileCard(lobbyNr: number): void {
+  const drawPileCard = games[lobbyNr].tempDrawPileCard;
+  games[lobbyNr].discardPileCards.push(drawPileCard);
+  games[lobbyNr].tempDrawPileCard = null;
+}

--- a/server/lib/games.ts
+++ b/server/lib/games.ts
@@ -195,7 +195,7 @@ export async function cardRevealClick(
   (await getPlayer(socketID)).cards[index].hidden = false;
 }
 
-export async function cardReplaceWithDiscardPileClick(
+export async function cardReplaceDiscardPileClick(
   socketID: string,
   lobbyNr: number,
   index: number
@@ -224,12 +224,25 @@ export async function cardReplaceWithDiscardPileClick(
     playerCards.splice(index + 1, 1);
   };
   replaceClickedCardWithDiscardPileCard();
+}
 
-  console.log("playercards", JSON.stringify(playerCards, null, 4));
-  console.log(
-    "discardpile",
-    JSON.stringify(games[lobbyNr].discardPileCards, null, 4)
-  );
+export async function cardReplaceDrawPileKeepClick(
+  socketID: string,
+  lobbyNr: number,
+  index: number
+): Promise<void> {
+  const playerCards = (await getPlayer(socketID)).cards;
+  const clickedCard = (await getPlayer(socketID)).cards[index];
+  const drawPileCard = games[lobbyNr].tempDrawPileCard;
+
+  const replaceClickedCardWithDrawPileCard = () => {
+    clickedCard.hidden = false;
+
+    const replacedCard = playerCards.splice(index, 1, drawPileCard);
+    games[lobbyNr].discardPileCards.push(replacedCard[0]);
+    games[lobbyNr].tempDrawPileCard = null;
+  };
+  replaceClickedCardWithDrawPileCard();
 }
 
 export async function checkCardsVerticalRow(socketID: string): Promise<void> {
@@ -346,10 +359,14 @@ export async function setNextActivePlayer(socketID: string): Promise<void> {
   }
 }
 
-export function getDrawPileCard(lobbyNr: number): Card {
+export function getNewDrawPileCard(lobbyNr: number): Card {
   const randomCard = getRandomCard(lobbyNr);
   randomCard.hidden = false;
   games[lobbyNr].tempDrawPileCard = randomCard;
   console.log(games[lobbyNr].tempDrawPileCard);
   return randomCard;
+}
+
+export function getCurrentDrawPileCard(lobbyNr: number): Card {
+  return games[lobbyNr].tempDrawPileCard;
 }

--- a/server/lib/statusMessages.ts
+++ b/server/lib/statusMessages.ts
@@ -9,6 +9,8 @@ export const status = {
   DRAWPILEDECISION: "Do you want to keep or discard your drawn card?",
   DRAWPILEDISCARD:
     "Card added to discard pile. Reveal a hidden card on your grid",
+  DRAWPILEDISCARDINVALID:
+    "Invalid card clicked. Please reveal a hidden card on your grid",
   DRAWDISCARDPILEKEEP: "Replace open or hidden card on your grid",
   DRAWDISCARDPILEKEEPOPEN:
     "Replaced open card. Replaced card added to discard pile",


### PR DESCRIPTION
- Removed rows are now non-clickable
- After clicking 'keep' the player can replace any card on his own cardgrid with the drawn card

You can actually take turns now and replace cards either with a random card from the drawpile, or with the card from discardpile.
Pretty neat!

Next up: Actions for clicking 'Discard'

Deployment: https://sisu-pipelin-keepcardac-zw6c4z.herokuapp.com/
Fixes #97 
Part of #79 